### PR TITLE
Emit controllable gate mapping comments

### DIFF
--- a/source/aig.cpp
+++ b/source/aig.cpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <unordered_map>
 #include <algorithm>
+#include <cstdio>
 #include <iterator>
 #include <iostream>
 #include <ctime>
@@ -180,7 +181,15 @@ unsigned AIG::copyGateFrom(const AIG* other, unsigned and_lit) {
 }
 
 void AIG::input2gate(unsigned input, unsigned rh0) {
+    aiger_symbol* symbol = aiger_is_input(this->spec, input);
+    std::string name = symbol && symbol->name ? symbol->name : "";
     aiger_redefine_input_as_and(this->spec, input, rh0, rh0);
+    if (!name.empty()) {
+        char comment[4096];
+        snprintf(comment, sizeof(comment), "controllable-gate %u %s", input,
+                 name.c_str());
+        aiger_add_comment(this->spec, comment);
+    }
     dbgMsg("Gated input " + std::to_string(input) + " with val = " +
            std::to_string(rh0));
 }


### PR DESCRIPTION
Teach `AIG::input2gate` to preserve the original controllable input name in an AIGER comment before redefining that input as an AND gate.

The emitted comment has the form:

```text
controllable-gate <lit> <name>
```

This lets downstream tools recover named controllable strategy functions from vanilla AbsSynthe output after controllable inputs have been replaced by gates.